### PR TITLE
Speed up and file size bug fix

### DIFF
--- a/gulp-source-scanner.js
+++ b/gulp-source-scanner.js
@@ -143,10 +143,13 @@ function scan(opts)
               if(new RegExp(absoluteIgnorePath+"/.+").test(file.path) || absoluteIgnorePath===file.path)
               {
                 ignore=true;
+                break;
               }
-
-              log("debug", (ignore?"I":"Not i")+"gnoring "+file.path);
             }
+          }
+
+          if (ignore) {
+            log('debug', 'Ignoring file : ' + file.path);
           }
         }
         else

--- a/gulp-source-scanner.js
+++ b/gulp-source-scanner.js
@@ -160,7 +160,8 @@ function scan(opts)
 
       if(ignore===false)
       {
-        if(opts.ignoreFilesLargerThanMB>(file.stat.size/1024) || opts.ignoreFilesLargerThanMB===0)
+        var fileSizeInMB = file.stat.size / (1024 * 1024);
+        if((fileSizeInMB < opts.ignoreFilesLargerThanMB) || (opts.ignoreFilesLargerThanMB=== 0))
         {
           // Execute all defined scanTypes in opts
           if("scanTypes" in opts)


### PR DESCRIPTION
As discussed in the [issue](https://github.com/neilstuartcraig/gulp-source-scanner/issues/1) yesterday Neil, here are the fixes I mentioned:

* early out of the ignore file comparison loop to avoid extraneous regex tests
* fix for incorrectly ignoring files over the maximum size set in the options.

Cheers.